### PR TITLE
[ODS-4850] Dbup during initdev errors with timeout on larger dataset

### DIFF
--- a/src/EdFi.Db.Deploy.sln
+++ b/src/EdFi.Db.Deploy.sln
@@ -1,8 +1,7 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
-MinimumVisualStudioVersion = 15.0.26124.0
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29609.76
+MinimumVisualStudioVersion = 16.0.29609.76
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Db.Deploy", "EdFi.Db.Deploy\EdFi.Db.Deploy.csproj", "{A78F6361-8B5A-40CC-A631-A6F88227B258}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EdFi.Db.Deploy.Tests", "..\tests\EdFi.Db.Deploy.Tests\EdFi.Db.Deploy.Tests.csproj", "{6CF6F52E-22C4-46C3-A1C2-2979D722A4F8}"

--- a/src/EdFi.Db.Deploy/Parameters/IOptions.cs
+++ b/src/EdFi.Db.Deploy/Parameters/IOptions.cs
@@ -24,7 +24,7 @@ namespace EdFi.Db.Deploy.Parameters
         [Option('c', "connectionString", Required = true, HelpText = "Connection string")]
         string ConnectionString { get; set; }
 
-        [Option('t', "timeOut", Default = 300, HelpText = "Command timeout in seconds")]
+        [Option('t', "timeOut", Default = 600, HelpText = "Command timeout in seconds")]
         int TimeoutInSeconds { get; set; }
 
         [Option('p', "filePaths", Separator = ',', HelpText = "Path to Files to be installed")]

--- a/src/EdFi.Db.Deploy/Parameters/IOptions.cs
+++ b/src/EdFi.Db.Deploy/Parameters/IOptions.cs
@@ -24,7 +24,7 @@ namespace EdFi.Db.Deploy.Parameters
         [Option('c', "connectionString", Required = true, HelpText = "Connection string")]
         string ConnectionString { get; set; }
 
-        [Option('t', "timeOut", Default = 60, HelpText = "Command timeout in seconds")]
+        [Option('t', "timeOut", Default = 300, HelpText = "Command timeout in seconds")]
         int TimeoutInSeconds { get; set; }
 
         [Option('p', "filePaths", Separator = ',', HelpText = "Path to Files to be installed")]

--- a/src/EdFi.Db.Deploy/Specifications/TimeoutSpecification.cs
+++ b/src/EdFi.Db.Deploy/Specifications/TimeoutSpecification.cs
@@ -17,7 +17,7 @@ namespace EdFi.Db.Deploy.Specifications
 
             if (obj.TimeoutInSeconds < 0)
             {
-                ErrorMessages.Add("Connection Timeout must be greater than or equal to 0 seconds");
+                ErrorMessages.Add("Command Timeout must be greater than or equal to 0 seconds");
             }
 
             return !ErrorMessages.Any();


### PR DESCRIPTION
Note, this includes a quick fix to the solution file to update the required minimum version of Visual Studio to 2019.  This ensures the solution opens in VS2019 on systems with more than VS2019 installed, since VS2019 is required to work with  .Net Core 3.1 solutions. This was sourced from the main ODS/API solution.